### PR TITLE
Update repository links for tkuitocc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ If neither is set, the app uses the public GitHub JSON fallback in `src/componen
 ## Deployment (GitHub Pages)
 
 Deployment is handled directly by GitHub Actions on pushes to `main`, publishing
-`dist` to GitHub Pages at `https://cantpr09ram.github.io/AZQUERYSUCKS/`.
+`dist` to GitHub Pages at `https://tkuitocc.github.io/AZQUERYSUCKS/`.

--- a/src/components/course-scheduler-content.tsx
+++ b/src/components/course-scheduler-content.tsx
@@ -10,7 +10,7 @@ import { parseTimes } from "@/utils/parse-times";
 const COURSES_URL =
   import.meta.env.NEXT_PUBLIC_COURSES_URL ??
   import.meta.env.VITE_COURSES_URL ??
-  "https://raw.githubusercontent.com/cantpr09ram/AZQUERYSUCKS/refs/heads/main/courses.json";
+  "https://raw.githubusercontent.com/tkuitocc/AZQUERYSUCKS/refs/heads/main/courses.json";
 
 interface CourseSchedulerContentProps {
   selectedCourseSeqs: string[];

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -14,7 +14,7 @@ export function Footer() {
           </a>{" "}
           . The source code is available on{" "}
           <a
-            href="https://github.com/cantpr09ram/AZQUERYSUCKS"
+            href="https://github.com/tkuitocc/AZQUERYSUCKS"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-4 decoration-muted-foreground/60 hover:text-foreground hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -24,7 +24,7 @@ export const Route = createRootRoute({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://cantpr09ram.github.io/AZQUERYSUCKS/",
+        content: "https://tkuitocc.github.io/AZQUERYSUCKS/",
       },
       { property: "og:title", content: "AZQUERYSUCKS" },
       { property: "og:description", content: "so I made one" },


### PR DESCRIPTION
## Summary
- update default course data source to tkuitocc repo
- refresh GitHub/OG URLs and deployment link to the new owner

## Testing
- not run (link updates only)