### PR TITLE
Hot Fix: repo URL casing for Pages and GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pnpm install
 pnpm dev
 ```
 
-Open `http://localhost:5173/AZQUERYSUCKS/`.
+Open `http://localhost:5173/azquerysucks/`.
 
 ## Environment
 
@@ -36,4 +36,4 @@ If neither is set, the app uses the public GitHub JSON fallback in `src/componen
 ## Deployment (GitHub Pages)
 
 Deployment is handled directly by GitHub Actions on pushes to `main`, publishing
-`dist` to GitHub Pages at `https://tkuitocc.github.io/AZQUERYSUCKS/`.
+`dist` to GitHub Pages at `https://tkuitocc.github.io/azquerysucks/`.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,13 +4,13 @@ export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
   use: {
-    baseURL: "http://localhost:4173/AZQUERYSUCKS/",
+    baseURL: "http://localhost:4173/azquerysucks/",
     trace: "on-first-retry",
   },
   webServer: {
     command:
       "pnpm build && pnpm start -- --host 0.0.0.0 --port 4173 --strictPort",
-    url: "http://localhost:4173/AZQUERYSUCKS/",
+    url: "http://localhost:4173/azquerysucks/",
     timeout: 180000,
     reuseExistingServer: !process.env.CI,
   },

--- a/src/components/course-scheduler-content.tsx
+++ b/src/components/course-scheduler-content.tsx
@@ -10,7 +10,7 @@ import { parseTimes } from "@/utils/parse-times";
 const COURSES_URL =
   import.meta.env.NEXT_PUBLIC_COURSES_URL ??
   import.meta.env.VITE_COURSES_URL ??
-  "https://raw.githubusercontent.com/tkuitocc/AZQUERYSUCKS/refs/heads/main/courses.json";
+  "https://raw.githubusercontent.com/tkuitocc/azquerysucks/refs/heads/main/courses.json";
 
 interface CourseSchedulerContentProps {
   selectedCourseSeqs: string[];

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -14,7 +14,7 @@ export function Footer() {
           </a>{" "}
           . The source code is available on{" "}
           <a
-            href="https://github.com/tkuitocc/azquerysucks"
+            href="https://github.com/tkuitocc/AZQUERYSUCKS"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-4 decoration-muted-foreground/60 hover:text-foreground hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -14,7 +14,7 @@ export function Footer() {
           </a>{" "}
           . The source code is available on{" "}
           <a
-            href="https://github.com/tkuitocc/AZQUERYSUCKS"
+            href="https://github.com/tkuitocc/azquerysucks"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-4 decoration-muted-foreground/60 hover:text-foreground hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -24,7 +24,7 @@ export const Route = createRootRoute({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://tkuitocc.github.io/AZQUERYSUCKS/",
+        content: "https://tkuitocc.github.io/azquerysucks/",
       },
       { property: "og:title", content: "AZQUERYSUCKS" },
       { property: "og:description", content: "so I made one" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  base: "/AZQUERYSUCKS/",
+  base: "/azquerysucks/",
   envPrefix: ["VITE_", "NEXT_PUBLIC_"],
   plugins: [
     tsconfigPaths(),


### PR DESCRIPTION
## Summary
- switch Pages and raw data URLs to lowercase repo slug
- keep the GitHub repo link using the displayed uppercase name

## Testing
- not run (link updates only)