### PR TITLE
Fix Pages deploy to publish client bundle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - run: pnpm build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: dist/client
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- publish the client build output for GitHub Pages
- ensure Pages serves root index.html from dist/client